### PR TITLE
MNT: Remove tracking of lfs files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,0 @@
-*.dat filter=lfs diff=lfs merge=lfs -text
-*.nii.gz filter=lfs diff=lfs merge=lfs -text
-*.h5 filter=lfs diff=lfs merge=lfs -text
-*.IMA filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ explanatory_doc/_build
 .vscode/
 ~$*.docx
 ~$*
+example_data/examples
+publication/figures/figure_*_data

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 8th April 2026 (V0.11)
+- Example data (in `example_data/examples`) removed from repository due to Github LFS bandwidth constraints. This data remains available at https://doi.org/10.5281/zenodo.5085448.
+- Similarly data used to create the original publication figures (in `publication/figures/figure_{4/5}_data`) was removed from the master branch tip. Data remains available through older commits.
+
 ## 20th May 2024 (V0.10)
 - Add `DIM_METCYCLE` for storing metabolite cycled data to the dimensions definitions.
 

--- a/example_data/README.md
+++ b/example_data/README.md
@@ -1,5 +1,7 @@
 # Example Data
 
+**This directory used to contain a subdirectory `examples` that contained the data listed below. Due to Github LFS bandwidth constraints the data was removed and can be found on the linked [Zenodo repository](https://doi.org/10.5281/zenodo.5085448).**
+
 ## List of example NIfTI-MRS data
 This file lists and explains the example data contained in this repository.
 

--- a/example_data/examples/example_01.h5
+++ b/example_data/examples/example_01.h5
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:044dbc93a2aab59a14d52977df7b92ec7eef0d57f0e6c76ef8e8960a9bb05fe6
-size 33560592

--- a/example_data/examples/example_01.nii.gz
+++ b/example_data/examples/example_01.nii.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0b2511cb80b8f79e60112f253935225dd86d94fb931501c26a63feb559db1b0b
-size 31195147

--- a/example_data/examples/example_02.nii.gz
+++ b/example_data/examples/example_02.nii.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:172e6117887ce55aa2677df85801cec38a62dd4fbc50c58b9b650ac5c2afc356
-size 31195524

--- a/example_data/examples/example_03.nii.gz
+++ b/example_data/examples/example_03.nii.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:54c583ed4c44bd1000360734564abca7e62b55a3057d933f8cc2241fb34d4767
-size 47225175

--- a/example_data/examples/example_04.h5
+++ b/example_data/examples/example_04.h5
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c9879aee1e1067947be8afaa309c6acbb254bc92eb69a83c23eb7a46f4a9dc7a
-size 33560592

--- a/example_data/examples/example_04.nii.gz
+++ b/example_data/examples/example_04.nii.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:61e5d028cfc35cf4019d9bec30c1fc2c54cccf33a2b2908b51dabc5fc455eb81
-size 31143020

--- a/example_data/examples/example_05.nii.gz
+++ b/example_data/examples/example_05.nii.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6ebc305ed85a844b7010c868155073d0b6eee4867c985153c192fc5e7331da7f
-size 984403

--- a/example_data/examples/example_06.nii.gz
+++ b/example_data/examples/example_06.nii.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e57ab8b46c66e47102753ad8c6ea4a1ffd6e77bb4045399a111ad62b5ba237e6
-size 2541261

--- a/example_data/examples/example_07.nii.gz
+++ b/example_data/examples/example_07.nii.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:23d251dba65fbbc79c5f24e13f2aa38f5fef9da608a03239be49578aeb7934c4
-size 1269820

--- a/example_data/examples/example_08.nii.gz
+++ b/example_data/examples/example_08.nii.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:94941631d54834135df56f3e23c7740cf68d1f806dd5ccff249dfade7f783df1
-size 1269850

--- a/example_data/examples/example_09.nii.gz
+++ b/example_data/examples/example_09.nii.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2a71a51f2aa547895fa36eb4ca44d00ba2a2b10a6fc98f7b8f69e83f288312ff
-size 630955

--- a/example_data/examples/example_10.nii.gz
+++ b/example_data/examples/example_10.nii.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e8ccfe37cb3999df09a2c3859dd054e33c19ec04d2ba54c740003815408c8836
-size 32541

--- a/publication/figures/figure_4_data/fsl_mrs/metab.nii.gz
+++ b/publication/figures/figure_4_data/fsl_mrs/metab.nii.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:08b4b9f7204f77cec67de89d946c9ca12464f22f40eea9171ed2e1b20800caab
-size 16981

--- a/publication/figures/figure_4_data/fsl_mrs/wref.nii.gz
+++ b/publication/figures/figure_4_data/fsl_mrs/wref.nii.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:77cf59a50fa3055978cf5ca0a65dea060c8e77f2b3959a90b37d731b46a41f27
-size 9403

--- a/publication/figures/figure_4_data/osprey/sub-01_ses-01_mrs_sub-01_ses-01_SVS-ref_REF.nii.gz
+++ b/publication/figures/figure_4_data/osprey/sub-01_ses-01_mrs_sub-01_ses-01_SVS-ref_REF.nii.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cf508835cb4f5749566e0bf1cacfee7e840b4f2a5fc7293cb3bcec0edd8aa0d5
-size 32631

--- a/publication/figures/figure_4_data/osprey/sub-01_ses-01_mrs_sub-01_ses-01_SVS_A.nii.gz
+++ b/publication/figures/figure_4_data/osprey/sub-01_ses-01_mrs_sub-01_ses-01_SVS_A.nii.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:eda6bf40adc16657ca1ec731586dd8eb85a6bcedad002a9186d02afdb4d178dd
-size 32511

--- a/publication/figures/figure_4_data/raw_suppressed.nii.gz
+++ b/publication/figures/figure_4_data/raw_suppressed.nii.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:33a70f57eb338793364fbfdf395fcb7824dc05bae1a4202f556e74d21bc37d68
-size 31195518

--- a/publication/figures/figure_4_data/raw_wref.nii.gz
+++ b/publication/figures/figure_4_data/raw_wref.nii.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:995a16bfd38c8b146976233e44a939d1f1df83c123df3cbdf6c370a317c5229b
-size 498425

--- a/publication/figures/figure_4_data/spant/proc_supressed.nii.gz
+++ b/publication/figures/figure_4_data/spant/proc_supressed.nii.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ebcbb1f52f88a02fa855c8fc21e94168eaaaa60ab08e3a8afcbbf845b223e04d
-size 32403

--- a/publication/figures/figure_4_data/spant/proc_wref.nii.gz
+++ b/publication/figures/figure_4_data/spant/proc_wref.nii.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:40ab816db4412193eae96deb3974d38033695fb17eb218914e9f4134887769f7
-size 18611

--- a/publication/figures/figure_5_data/mrsi/fit/concs/internal/PCho+GPC.nii.gz
+++ b/publication/figures/figure_5_data/mrsi/fit/concs/internal/PCho+GPC.nii.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9bf9bc547c053aaf50c809f7249d1e3b623d5eb69619d9915f64aea9f7ffeeed
-size 1831

--- a/publication/figures/figure_5_data/mrsi/fit/fit/baseline.nii.gz
+++ b/publication/figures/figure_5_data/mrsi/fit/fit/baseline.nii.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2057f55a15f3f92558091b2269ed74c318b15c5e37cda6d152b90e635d785063
-size 844255

--- a/publication/figures/figure_5_data/mrsi/fit/fit/fit.nii.gz
+++ b/publication/figures/figure_5_data/mrsi/fit/fit/fit.nii.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d3b71b2a3ff33f8e0e98925f10e28fcf88e114cea8aef95db3e3321dbbbd317b
-size 843990

--- a/publication/figures/figure_5_data/mrsi/fit/fit/residual.nii.gz
+++ b/publication/figures/figure_5_data/mrsi/fit/fit/residual.nii.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8a70ded5bf02dd732f158175411ed9f68bf3dd28f0db2db7dfd50c1c613317ab
-size 841505

--- a/publication/figures/figure_5_data/mrsi/mrsi.nii.gz
+++ b/publication/figures/figure_5_data/mrsi/mrsi.nii.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9ae196d5ec7e4680426477e944c12b912f2978c0359f7947a08ab0d9439d7061
-size 1056494

--- a/publication/figures/figure_5_data/mrsi/t1.nii.gz
+++ b/publication/figures/figure_5_data/mrsi/t1.nii.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:377bd05b940831cb0063846d932c4b064c26e25feb44e46e83b8878b174e3f59
-size 8121888

--- a/publication/figures/figure_5_data/svs/mrs_coilcombined.nii.gz
+++ b/publication/figures/figure_5_data/svs/mrs_coilcombined.nii.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d6b9d88dabc7603658173b18af86ad0fd23a3c9dd0c5831dda9c1a89f9157179
-size 1958418

--- a/publication/figures/figure_5_data/svs/t1.nii.gz
+++ b/publication/figures/figure_5_data/svs/t1.nii.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2755dc83e2832fc646f6dcda390ebe12eaf65fcabc19311c9f399831d6c5fde6
-size 17391407


### PR DESCRIPTION
- Example data (in `example_data/examples`) removed from repository due to Github LFS bandwidth constraints. This data remains available at https://doi.org/10.5281/zenodo.5085448.
- Similarly data used to create the original publication figures (in `publication/figures/figure_{4/5}_data`) was removed from the master branch tip. Data remains available through older commits.