### PR TITLE
ENH: Add RxOffset and SpecFreqChemShift

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Minimal examples of interpreting NIfTI-MRS in are contained in Java, Python, MAT
 ## This Repository
 The repository currently holds:
 - An up-to-date copy of the format specification
-- A set of example data, including those referred to by the specification.
+- A link to a set of example data, including those referred to by the specification.
 - Original data from which examples are generated and code for generation (in jupyter notebook format).
 - Links (via git submodules) to repositories containing minimal examples in java, matlab, python, and R.
 - Manuscript, supporting information, figures, and figure generation code for the associated publication.

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,9 @@
 # Changelog
 
-## 8th April 2026 (V0.11)
+## 9th April 2026 (V0.11)
+- Added `RxOffset` standard-defined metadata key - to track ADC offsets from `SpectrometerFrequency`.
+- Added `SpecFreqChemShift` standard-defined metadata key - to indicate the nominal chemical shift value at the `SpectrometerFrequency`. E.g. 4.65 for a 1H sequence centred on water.
+- Updated description of `AcquisitionStartTime` to indicate its use for FID as well as echo based sequences
 - Example data (in `example_data/examples`) removed from repository due to Github LFS bandwidth constraints. This data remains available at https://doi.org/10.5281/zenodo.5085448.
 - Similarly data used to create the original publication figures (in `publication/figures/figure_{4/5}_data`) was removed from the master branch tip. Data remains available through older commits.
 

--- a/definitions.json
+++ b/definitions.json
@@ -59,7 +59,7 @@
         "AcquisitionStartTime": {
             "type": ["number"],
             "units": "s",
-            "doc": "Time, relative to EchoTime, that the acquisition starts. Positive values indicate a time after the EchoTime, negative indicate before the EchoTime, a value of zero indicates no offset. Units: Seconds",
+            "doc": "Time, relative to EchoTime, or time of FID generation, that the acquisition starts. Positive values indicate a time after the EchoTime, negative indicate before the EchoTime, a value of zero indicates no offset. Units: Seconds",
             "anon": false},
         "ExcitationFlipAngle": {
             "type": ["number"],
@@ -70,6 +70,16 @@
             "type": ["number"],
             "units": "ppm",
             "doc": "Transmit chemical shift offset from SpectrometerFrequency",
+            "anon": false},
+        "RxOffset": {
+            "type": ["number"],
+            "units": "ppm",
+            "doc": "Receive event chemical shift offset from SpectrometerFrequency.",
+            "anon": false},
+        "SpecFreqChemShift": {
+            "type": ["number"],
+            "units": "ppm",
+            "doc": "The nominal chemical shift value at the SpectrometerFrequency (AKA central frequency).",
             "anon": false},
         "VOI": {
             "type": ["array", "array", "number"],

--- a/specification.MD
+++ b/specification.MD
@@ -372,6 +372,7 @@ _Example 4: A fingerprinting based example. Dimension 5 is used to index changes
 
 [https://www.nature.com/articles/sdata201644](https://www.nature.com/articles/sdata201644)
 
+[MRS-BIDS, an extension to the Brain Imaging Data Structure for magnetic resonance spectroscopy](https://www.nature.com/articles/s41597-025-05543-2)
 
 #### 2.5.3 DICOM
 
@@ -472,7 +473,7 @@ This appendix contains the standard-defined metadata keys. Keys have been groupe
    <td>AcquisitionStartTime</td>
    <td>number</td>
    <td>s</td>
-   <td>Time, relative to EchoTime, that the acquisition starts. Positive values indicate a time after the EchoTime, negative indicate before the EchoTime, a value of zero indicates no offset. Units: Seconds</td>
+   <td>Time, relative to EchoTime, or time of FID generation, that the acquisition starts. Positive values indicate a time after the EchoTime, negative indicate before the EchoTime, a value of zero indicates no offset. Units: Seconds</td>
    <td>N</td>
   </tr>
   <tr>
@@ -487,6 +488,20 @@ This appendix contains the standard-defined metadata keys. Keys have been groupe
    <td>number</td>
    <td>ppm</td>
    <td>Transmit chemical shift offset from SpectrometerFrequency</td>
+   <td>N</td>
+  </tr>
+  <tr>
+   <td>RxOffset</td>
+   <td>number</td>
+   <td>ppm</td>
+   <td>Receive event chemical shift offset from SpectrometerFrequency.</td>
+   <td>N</td>
+  </tr>
+  <tr>
+   <td>SpecFreqChemShift</td>
+   <td>number</td>
+   <td>ppm</td>
+   <td>The nominal chemical shift value at the SpectrometerFrequency (AKA central frequency).</td>
    <td>N</td>
   </tr>
   <tr>


### PR DESCRIPTION
- Added `RxOffset` standard-defined metadata key - to track ADC offsets from `SpectrometerFrequency`.
- Added `SpecFreqChemShift` standard-defined metadata key - to indicate the nominal chemical shift value at the `SpectrometerFrequency`. E.g. 4.65 for a 1H sequence centred on water.
- Updated description of `AcquisitionStartTime` to indicate its use for FID as well as echo based sequences